### PR TITLE
add Linux build support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,16 +19,16 @@ OUTPUT	:= output
 
 # define source directory 运行时修改此处路径
 SRC		:= src/$(dir) #// 传递 var 变量定义执行文件目录
-CLEAN_SRC		:= src\$(dir)\*.o #// 删除所有.o文件
+CLEAN_SRC		:= src/$(dir)/*.o #// 删除所有.o文件
 
 # define include directory
 INCLUDE	:= include
 
 # define lib directory
 LIB		:= lib
-LIBRARIES	:= -lglad -lglfw3dll -llibassimp
 
 ifeq ($(OS),Windows_NT)
+LIBRARIES	:= -lglad -lglfw3dll -llibassimp
 MAIN	:= main.exe
 SOURCEDIRS	:= $(SRC)
 INCLUDEDIRS	:= $(INCLUDE)
@@ -37,6 +37,7 @@ FIXPATH = $(subst /,/,$1)
 RM			:= del /q a/f
 MD	:= mkdir
 else
+LIBRARIES	:= -lglad -lglfw -ldl -lpthread
 MAIN	:= main
 SOURCEDIRS	:= $(shell find $(SRC) -type d)
 INCLUDEDIRS	:= $(shell find $(INCLUDE) -type d)
@@ -66,7 +67,7 @@ OBJECTS		:= $(SOURCES:.cpp=.o)
 # deleting dependencies appended to the file from 'make depend'
 #
 
-OUTPUTMAIN	:= $(call FIXPATH,$(OUTPUT)\$(MAIN))
+OUTPUTMAIN	:= $(call FIXPATH,$(OUTPUT)/$(MAIN))
 
 all: $(OUTPUT) $(MAIN)
 	@echo Executing 'all' complete!
@@ -91,5 +92,5 @@ clean:
 	@echo Cleanup complete!
 # 此处./src/$(dir) 传递main函数 argv 的参数
 run: all
-	.\$(OUTPUTMAIN) src/$(dir)/
+	./$(OUTPUTMAIN) src/$(dir)/
 	@echo Executing 'run: all' complete!

--- a/README.md
+++ b/README.md
@@ -536,6 +536,7 @@
 -   glfw 下载 [`Windows pre-compiled binaries`](https://www.glfw.org/download.html)
 
     > 选择**Windows pre-compiled binaries**，因为我们使用的 MinGW 所以选择 [32-bit Windows binaries](https://github.com/glfw/glfw/releases/download/3.3.4/glfw-3.3.4.bin.WIN32.zip)
+    > 对于 Ubuntu，通过 `sudo apt install libglfw3-dev libglfw3` 安装 glfw
 
 -   glad [在线服务](https://glad.dav1d.de/) 生成静态库
     ```
@@ -553,6 +554,7 @@
     SOURCES	+= include/imgui/imgui.cpp include/imgui/imgui_demo.cpp include/imgui/imgui_draw.cpp include/imgui/imgui_widgets.cpp
     ```
 -   assimp 下载已编译好的文件 [Assimp3-1-1_MinGW4-8-1_Win32.zip](https://www.mediafire.com/file/jjiv41rv8euy3dt/Assimp3-1-1_MinGW4-8-1_Win32.zip/file)
+    > 对于 Ubuntu，通过 `sudo apt install libassimp-dev` 安装 assimp
 
 -   [参考 Makefile 文件](https://github.com/yocover/start-learning-opengl/blob/main/Makefile)
 


### PR DESCRIPTION
Add Linux build support by modifying Makefile, and already tested on Ubuntu 20(gcc9.4) and Windows 10(MinGW32). Can merge safely. Thanks!